### PR TITLE
Add robust IPC node and tests

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -3,7 +3,9 @@ find_package(stduuid  CONFIG REQUIRED)
 find_package(lux-cxx		 REQUIRED COMPONENTS concurrent compile_time)
 
 set(LUX_COMMUNICATION_NODE_SRC
-	${CMAKE_CURRENT_SOURCE_DIR}/src/Subscriber.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Subscriber.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/Executor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ZmqContext.cpp
 )
 
 if(WIN32)
@@ -30,13 +32,14 @@ component_include_directories(
 )
 
 target_link_libraries(
-	node 
-	PUBLIC
-	# cppzmq
-	lux::cxx::concurrent
-	lux::cxx::compile_time
-	PRIVATE
-	stduuid
+        node
+        PUBLIC
+        cppzmq
+        zmq
+        lux::cxx::concurrent
+        lux::cxx::compile_time
+        PRIVATE
+        stduuid
 )
 
 component_add_internal_dependencies(

--- a/node/include/lux/communication/interprocess/Node.hpp
+++ b/node/include/lux/communication/interprocess/Node.hpp
@@ -1,0 +1,116 @@
+#pragma once
+#include <vector>
+#include <memory>
+#include <mutex>
+#include <atomic>
+#include <functional>
+#include "ZmqPubSub.hpp"
+#include "../introprocess/Queue.hpp"
+#include "../introprocess/CallbackGroup.hpp"
+#include "../introprocess/SubscriberBase.hpp"
+
+namespace lux::communication::interprocess {
+
+class Node {
+public:
+    explicit Node(const std::string& name, int domain = 0)
+        : name_(name), domain_(domain) {
+        default_group_ = std::make_shared<introprocess::CallbackGroup>(introprocess::CallbackGroupType::MutuallyExclusive);
+    }
+    ~Node() { stop(); }
+
+    template<typename T>
+    std::shared_ptr<Publisher<T>> createPublisher(const std::string& topic) {
+        auto pub = std::make_shared<Publisher<T>>(topic);
+        std::lock_guard<std::mutex> lock(mutex_);
+        pubs_.push_back(pub);
+        return pub;
+    }
+
+    template<typename T, typename F>
+    std::shared_ptr<introprocess::ISubscriberBase> createSubscriber(const std::string& topic, F&& cb,
+            std::shared_ptr<introprocess::CallbackGroup> group = nullptr) {
+        if(!group) group = default_group_;
+        auto sub = std::make_shared<NodeSubscriber<T>>(topic, std::forward<F>(cb), group);
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            subs_.push_back(sub);
+        }
+        return sub;
+    }
+
+    std::shared_ptr<introprocess::CallbackGroup> getDefaultCallbackGroup() const { return default_group_; }
+
+    void stop() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for(auto& s : subs_) {
+            static_cast<NodeSubscriberBase*>(s.get())->stop();
+        }
+    }
+
+private:
+    class NodeSubscriberBase : public introprocess::ISubscriberBase {
+    public:
+        NodeSubscriberBase() : introprocess::ISubscriberBase(nextId()) {}
+        virtual void stop() = 0;
+    private:
+        static int nextId() { static std::atomic<int> id{0}; return id++; }
+    };
+
+    template<typename T>
+    class NodeSubscriber : public NodeSubscriberBase {
+    public:
+        using Callback = std::function<void(const T&)>;
+        NodeSubscriber(const std::string& topic, Callback cb,
+                       std::shared_ptr<introprocess::CallbackGroup> group)
+            : callback_(std::move(cb)), group_(std::move(group)) {
+            zmq_sub_ = std::make_unique<Subscriber<T, std::function<void(const T&)>>>(
+                topic, [this](const T& m){ enqueue(m); });
+        }
+        ~NodeSubscriber() override { stop(); }
+        void stop() override { if(zmq_sub_) zmq_sub_->stop(); }
+
+        void enqueue(const T& msg) {
+            introprocess::push(queue_, std::make_shared<T>(msg));
+            if(group_ && setReadyIfNot()) group_->notify(this);
+        }
+
+        void takeAll() override {
+            introprocess::message_t<T> m;
+            while(introprocess::try_pop(queue_, m)) {
+                if(callback_) callback_(*m);
+            }
+            clearReady();
+        }
+
+        bool setReadyIfNot() override {
+            bool expected=false;
+            return ready_.compare_exchange_strong(expected, true,
+                std::memory_order_acq_rel, std::memory_order_acquire);
+        }
+        void clearReady() override { ready_.store(false, std::memory_order_release); }
+    private:
+        std::unique_ptr<Subscriber<T, std::function<void(const T&)>>> zmq_sub_;
+        Callback callback_;
+        std::shared_ptr<introprocess::CallbackGroup> group_;
+        introprocess::queue_t<T> queue_;
+        std::atomic<bool> ready_{false};
+
+        void drainAll(std::vector<introprocess::TimeExecEntry>& out) override {
+            introprocess::message_t<T> m;
+            while(introprocess::try_pop(queue_, m)) {
+                auto inv = [cb=callback_, msg=m]() mutable { if(cb) cb(*msg); };
+                out.push_back({0, std::move(inv)});
+            }
+        }
+    };
+
+    std::string name_;
+    int domain_;
+    mutable std::mutex mutex_;
+    std::vector<std::shared_ptr<void>> pubs_;
+    std::vector<std::shared_ptr<introprocess::ISubscriberBase>> subs_;
+    std::shared_ptr<introprocess::CallbackGroup> default_group_;
+};
+
+} // namespace lux::communication::interprocess

--- a/node/include/lux/communication/interprocess/ZmqPubSub.hpp
+++ b/node/include/lux/communication/interprocess/ZmqPubSub.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <string>
+#include <thread>
+#include <functional>
+#include <atomic>
+#include <optional>
+#include <cstring>
+#include <zmq.hpp>
+#include "lux/communication/visibility.h"
+
+#include "lux/communication/UdpMultiCast.hpp"
+
+namespace lux::communication::interprocess {
+
+LUX_COMMUNICATION_PUBLIC zmq::context_t& globalContext();
+
+inline std::string defaultEndpoint(const std::string& topic)
+{
+#ifdef _WIN32
+    size_t h = std::hash<std::string>{}(topic);
+    return "tcp://127.0.0.1:" + std::to_string(20000 + (h % 10000));
+#else
+    return "ipc:///tmp/" + topic + ".ipc";
+#endif
+}
+
+inline void sendDiscovery(const std::string& topic, const std::string& endpoint)
+{
+    try {
+        UdpMultiCast mc{"239.255.0.1", 30000};
+        std::string msg = topic + ':' + endpoint;
+        mc.send(msg);
+    } catch (...) {
+    }
+}
+
+inline std::optional<std::string> waitDiscovery(const std::string& topic, std::chrono::milliseconds timeout = std::chrono::milliseconds{200})
+{
+    try {
+        UdpMultiCast mc{"239.255.0.1", 30000};
+        mc.bind();
+        char buf[256];
+        SockAddr from{};
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < timeout) {
+            int ret = mc.recvFrom(buf, sizeof(buf)-1, from);
+            if (ret > 0) {
+                buf[ret] = '\0';
+                std::string s(buf);
+                auto pos = s.find(':');
+                if (pos != std::string::npos) {
+                    std::string t = s.substr(0, pos);
+                    if (t == topic) {
+                        return s.substr(pos+1);
+                    }
+                }
+            } else {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+        }
+    } catch (...) {
+    }
+    return std::nullopt;
+}
+
+template<typename T>
+class Publisher
+{
+public:
+    explicit Publisher(const std::string& topic, std::string endpoint = "")
+        : topic_(topic),
+          endpoint_(endpoint.empty() ? defaultEndpoint(topic) : std::move(endpoint)),
+          socket_(globalContext(), zmq::socket_type::pub)
+    {
+        socket_.bind(endpoint_);
+        sendDiscovery(topic_, endpoint_);
+    }
+
+    void publish(const T& msg)
+    {
+        zmq::message_t m(sizeof(T));
+        std::memcpy(m.data(), &msg, sizeof(T));
+        socket_.send(m, zmq::send_flags::none);
+    }
+
+private:
+    std::string topic_;
+    std::string endpoint_;
+    zmq::socket_t socket_;
+};
+
+template<typename T, typename Callback>
+class Subscriber
+{
+public:
+    Subscriber(const std::string& topic, Callback cb)
+        : topic_(topic), callback_(std::move(cb)), socket_(globalContext(), zmq::socket_type::sub)
+    {
+        auto ep = waitDiscovery(topic_);
+        if (!ep) {
+            endpoint_ = defaultEndpoint(topic_);
+        } else {
+            endpoint_ = *ep;
+        }
+        socket_.set(zmq::sockopt::subscribe, "");
+        socket_.set(zmq::sockopt::rcvtimeo, 100);
+        socket_.connect(endpoint_);
+        running_ = true;
+        thread_ = std::thread([this]{ recvLoop(); });
+    }
+
+    ~Subscriber()
+    {
+        stop();
+    }
+
+    void stop()
+    {
+        if (running_) {
+            running_ = false;
+            if (thread_.joinable())
+                thread_.join();
+        }
+    }
+
+private:
+    void recvLoop()
+    {
+        while (running_) {
+            zmq::message_t msg;
+            if (socket_.recv(msg, zmq::recv_flags::none)) {
+                T value;
+                std::memcpy(&value, msg.data(), sizeof(T));
+                callback_(value);
+            }
+        }
+    }
+
+    std::string topic_;
+    std::string endpoint_;
+    zmq::socket_t socket_;
+    Callback callback_;
+    std::thread thread_;
+    std::atomic<bool> running_{false};
+};
+
+} // namespace lux::communication::interprocess
+

--- a/node/include/lux/communication/introprocess/Executor.hpp
+++ b/node/include/lux/communication/introprocess/Executor.hpp
@@ -30,7 +30,7 @@ namespace lux::communication::introprocess
     {
     public:
         Executor() : running_(false) {}
-        virtual ~Executor() { stop(); }
+        virtual ~Executor();
 
         /**
          * @brief Adds a callback group to the executor.

--- a/node/include/lux/communication/introprocess/Node.hpp
+++ b/node/include/lux/communication/introprocess/Node.hpp
@@ -263,16 +263,5 @@ namespace lux::communication::introprocess
         }
     }
 
-    void Executor::addNode(std::shared_ptr<Node> node)
-    {
-        if (!node) return;
-        // For example, add the node's default callback group to the Executor
-        auto default_group = node->getDefaultCallbackGroup();
-        if (default_group)
-        {
-            addCallbackGroup(default_group);
-        }
-        // If you want to add all subscriber callback groups under the node more granularly,
-        // you can implement more complex interfaces in Node.
-    }
+
 }

--- a/node/src/Executor.cpp
+++ b/node/src/Executor.cpp
@@ -1,0 +1,13 @@
+#include "lux/communication/introprocess/Executor.hpp"
+#include "lux/communication/introprocess/Node.hpp"
+
+namespace lux::communication::introprocess {
+Executor::~Executor() { stop(); }
+void Executor::addNode(std::shared_ptr<Node> node) {
+    if (!node) return;
+    auto default_group = node->getDefaultCallbackGroup();
+    if (default_group) {
+        addCallbackGroup(default_group);
+    }
+}
+}

--- a/node/src/UdpMultiCastImplPosix.cpp
+++ b/node/src/UdpMultiCastImplPosix.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <poll.h>
+#include <fcntl.h>
 
 #include "lux/communication/visibility.h"
 
@@ -16,8 +17,11 @@ namespace lux::communication
 		UdpMultiCastImpl(std::string_view addr, int prt)
 		: addr(addr), port(prt)
 		{	
-			sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-			assert(sock != -1);
+                        sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+                        assert(sock != -1);
+
+                        int flags = fcntl(sock, F_GETFL, 0);
+                        fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 
 			int on = 1;
 			auto rst = setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &on, sizeof(on));

--- a/node/src/UdpMultiCastImplWin.cpp
+++ b/node/src/UdpMultiCastImplWin.cpp
@@ -16,9 +16,10 @@ namespace lux::communication
 			int rst = WSAStartup(MAKEWORD(2, 2), &wsaData);
 			assert((rst == 0, "WSAStartup failed with error"));
 			
-			sock = socket(AF_INET, SOCK_DGRAM, 0);
-
-			assert(sock != INVALID_SOCKET);
+                        sock = socket(AF_INET, SOCK_DGRAM, 0);
+                        assert(sock != INVALID_SOCKET);
+                        u_long mode = 1;
+                        ioctlsocket(sock, FIONBIO, &mode); // non-blocking
 
 			BOOL reuse = TRUE;
 			rst = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char*)&reuse, sizeof(reuse));

--- a/node/src/ZmqContext.cpp
+++ b/node/src/ZmqContext.cpp
@@ -1,0 +1,8 @@
+#include "lux/communication/interprocess/ZmqPubSub.hpp"
+
+namespace lux::communication::interprocess {
+zmq::context_t& globalContext() {
+    static zmq::context_t ctx{1};
+    return ctx;
+}
+}

--- a/node/test/CMakeLists.txt
+++ b/node/test/CMakeLists.txt
@@ -3,3 +3,9 @@ target_link_libraries(node_test PRIVATE lux::communication::node)
 
 add_executable(timeorder_executor_test timeorder_executor_test.cpp)
 target_link_libraries(timeorder_executor_test PRIVATE lux::communication::node)
+
+add_executable(communication_intra_inter_test communication_intra_inter_test.cpp)
+target_link_libraries(communication_intra_inter_test PRIVATE lux::communication::node)
+
+add_executable(executor_interprocess_test executor_interprocess_test.cpp)
+target_link_libraries(executor_interprocess_test PRIVATE lux::communication::node)

--- a/node/test/communication_intra_inter_test.cpp
+++ b/node/test/communication_intra_inter_test.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <vector>
+#include <memory>
+
+#include <lux/communication/introprocess/Node.hpp>
+#include <lux/communication/interprocess/Node.hpp>
+#include <lux/communication/introprocess/Executor.hpp>
+
+struct Msg { int value; };
+
+// Test RAII lifecycle for interprocess publisher/subscriber
+void testLifecycle()
+{
+    using namespace lux::communication;
+    std::cout << "\n=== lifecycle test ===\n";
+    {
+        interprocess::Node nodeA("A");
+        interprocess::Node nodeB("B");
+
+        std::atomic<int> count{0};
+        auto exec = std::make_shared<introprocess::SingleThreadedExecutor>();
+        exec->addCallbackGroup(nodeB.getDefaultCallbackGroup());
+        std::thread th([&]{ exec->spin(); });
+
+        auto sub = nodeB.createSubscriber<Msg>("ping", [&](const Msg&m){count++;});
+        auto pub = nodeA.createPublisher<Msg>("ping");
+
+        for(int i=0;i<5;i++){ pub->publish(Msg{i}); std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
+        exec->stop();
+        th.join();
+    }
+    // destructors should stop without hang
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::cout << "[OK] lifecycle completed" << std::endl;
+}
+
+// Test intra and interprocess in same executor
+void testIntraInter()
+{
+    using namespace lux::communication;
+    std::cout << "\n=== intra & inter mixed ===\n";
+    auto domain = std::make_shared<introprocess::Domain>(1);
+    auto inode = std::make_shared<introprocess::Node>("inode", domain);
+    interprocess::Node pnode("pnode");
+
+    std::atomic<int> intraCount{0}, interCount{0};
+
+    auto ipub = inode->createPublisher<Msg>("ch");
+    auto isub = inode->createSubscriber<Msg>("ch", [&](const Msg&m){intraCount++;});
+
+    auto psub = pnode.createSubscriber<Msg>("ch", [&](const Msg&m){interCount++;});
+    auto ppub = pnode.createPublisher<Msg>("ch");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    auto exec = std::make_shared<introprocess::SingleThreadedExecutor>();
+    exec->addNode(inode);
+    exec->addCallbackGroup(pnode.getDefaultCallbackGroup());
+    std::thread th([&]{ exec->spin(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    for(int i=0;i<3;i++){ ipub->publish(Msg{i}); ppub->publish(Msg{i}); }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    exec->stop();
+    th.join();
+    std::cout << "intra="<<intraCount.load()<<" inter="<<interCount.load()<<"\n";
+}
+
+int main()
+{
+    testLifecycle();
+    testIntraInter();
+    return 0;
+}

--- a/node/test/executor_interprocess_test.cpp
+++ b/node/test/executor_interprocess_test.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <memory>
+
+#include <lux/communication/interprocess/Node.hpp>
+#include <lux/communication/introprocess/Executor.hpp>
+
+struct IntMsg { int value; };
+
+void runExecutorInterprocess()
+{
+    using namespace lux::communication;
+    interprocess::Node nodePub("pub");
+    interprocess::Node nodeSub("sub");
+
+    std::atomic<int> count{0};
+    auto exec = std::make_shared<introprocess::SingleThreadedExecutor>();
+    exec->addCallbackGroup(nodeSub.getDefaultCallbackGroup());
+    std::thread th([&]{ exec->spin(); });
+
+    auto sub = nodeSub.createSubscriber<IntMsg>("topic", [&](const IntMsg&m){count++;});
+    auto pub = nodePub.createPublisher<IntMsg>("topic");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    for(int i=0;i<10;i++){ pub->publish(IntMsg{i}); std::this_thread::sleep_for(std::chrono::milliseconds(5)); }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    exec->stop();
+    th.join();
+    std::cout << "received=" << count.load() << std::endl;
+}
+
+int main(){ runExecutorInterprocess(); return 0; }


### PR DESCRIPTION
## Summary
- support global ZeroMQ context for interprocess communication
- make UDP multicast sockets non blocking on POSIX and Windows
- implement interprocess `Node` using shared callback groups
- add lifecycle and executor tests for interprocess mode
- ensure subscriber threads exit via recv timeouts

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./node/test/communication_intra_inter_test`
- `./node/test/executor_interprocess_test`
