### PR TITLE
Add exported communication primitives

### DIFF
--- a/node/include/lux/communication/CallbackGroup.hpp
+++ b/node/include/lux/communication/CallbackGroup.hpp
@@ -8,9 +8,10 @@
 #include <unordered_set>
 #include <condition_variable>
 #include <lux/cxx/container/SparseSet.hpp>
-#include "SubscriberBase.hpp"
+#include <lux/communication/visibility.h>
+#include <lux/communication/SubscriberBase.hpp>
 
-namespace lux::communication::introprocess
+namespace lux::communication
 {
     // Forward declarations
     class Executor;
@@ -22,7 +23,7 @@ namespace lux::communication::introprocess
         Reentrant           // Execution in this group can be concurrent
     };
 
-    class CallbackGroup
+    class LUX_COMMUNICATION_PUBLIC CallbackGroup
     {
     public:
         explicit CallbackGroup(CallbackGroupType type = CallbackGroupType::MutuallyExclusive)

--- a/node/include/lux/communication/Executor.hpp
+++ b/node/include/lux/communication/Executor.hpp
@@ -8,16 +8,17 @@
 #include <thread>
 #include <unordered_set>
 
-#include "CallbackGroup.hpp"
-#include "SubscriberBase.hpp"
+#include <lux/communication/visibility.h>
+#include <lux/communication/CallbackGroup.hpp>
+#include <lux/communication/SubscriberBase.hpp>
 
 #include <lux/communication/builtin_msgs/common_msgs/timestamp.st.h>
 #include <lux/cxx/concurrent/ThreadPool.hpp>
 
-namespace lux::communication::introprocess
+namespace lux::communication
 {
     // Forward declaration of Node class.
-    class Node;
+    namespace introprocess { class Node; }
 
     /**
      * @brief Base Executor class responsible for scheduling and executing callbacks.
@@ -26,7 +27,7 @@ namespace lux::communication::introprocess
      * for executing callbacks. It handles waiting for new tasks and waking up when new data
      * arrives.
      */
-    class Executor : public std::enable_shared_from_this<Executor>
+    class LUX_COMMUNICATION_PUBLIC Executor : public std::enable_shared_from_this<Executor>
     {
     public:
         Executor() : running_(false) {}
@@ -71,7 +72,7 @@ namespace lux::communication::introprocess
          *
          * @param node Shared pointer to the Node to add.
          */
-        virtual void addNode(std::shared_ptr<Node> node);
+        virtual void addNode(std::shared_ptr<introprocess::Node> node);
 
         /**
          * @brief Processes available callbacks once.
@@ -183,7 +184,7 @@ namespace lux::communication::introprocess
      * Processes callbacks sequentially in a single thread. It iterates over all callback groups,
      * collects ready subscribers, and executes their callbacks by invoking takeAll().
      */
-    class SingleThreadedExecutor : public Executor
+    class LUX_COMMUNICATION_PUBLIC SingleThreadedExecutor : public Executor
     {
     public:
         SingleThreadedExecutor() = default;
@@ -232,7 +233,7 @@ namespace lux::communication::introprocess
      * - Mutually exclusive groups are processed sequentially in the current thread.
      * - Reentrant groups have their callbacks dispatched to the thread pool for parallel execution.
      */
-    class MultiThreadedExecutor : public Executor
+    class LUX_COMMUNICATION_PUBLIC MultiThreadedExecutor : public Executor
     {
     public:
         /**
@@ -342,7 +343,7 @@ namespace lux::communication::introprocess
      * This executor only accepts MutuallyExclusive type callback groups and uses an optional delay
      * window (time_offset) to account for late-arriving messages.
      */
-    class TimeOrderedExecutor : public Executor
+    class LUX_COMMUNICATION_PUBLIC TimeOrderedExecutor : public Executor
     {
     public:
         /**
@@ -685,4 +686,4 @@ namespace lux::communication::introprocess
         return result;
     }
 
-} // namespace lux::communication::introprocess
+} // namespace lux::communication

--- a/node/include/lux/communication/Queue.hpp
+++ b/node/include/lux/communication/Queue.hpp
@@ -16,7 +16,7 @@
 #   include <lux/cxx/concurrent/BlockingQueue.hpp>
 #endif
 
-namespace lux::communication::introprocess
+namespace lux::communication
 {
     template<typename T> using message_t = std::shared_ptr<T>;
 #if defined(LUX_HAS_MOODYCAMEL_CONCURRENTQUEUE)

--- a/node/include/lux/communication/SubscriberBase.hpp
+++ b/node/include/lux/communication/SubscriberBase.hpp
@@ -1,9 +1,10 @@
 #pragma once
 #include <functional>
 #include <cstddef>
+#include <lux/communication/visibility.h>
 #include <lux/cxx/compile_time/move_only_function.hpp>
 
-namespace lux::communication::introprocess
+namespace lux::communication
 {
     struct TimeExecEntry
     {
@@ -16,7 +17,7 @@ namespace lux::communication::introprocess
         }
     };
 
-    class ISubscriberBase
+    class LUX_COMMUNICATION_PUBLIC ISubscriberBase
     {
         friend class TimeOrderedExecutor;
     public:

--- a/node/include/lux/communication/interprocess/ZmqPubSub.hpp
+++ b/node/include/lux/communication/interprocess/ZmqPubSub.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <string>
+#include <thread>
+#include <functional>
+#include <atomic>
+#include <optional>
+#include <cstring>
+#include <zmq.hpp>
+
+#include <lux/communication/visibility.h>
+#include "lux/communication/UdpMultiCast.hpp"
+
+namespace lux::communication::interprocess {
+
+inline zmq::context_t& globalContext()
+{
+    static zmq::context_t ctx{1};
+    return ctx;
+}
+
+inline std::string defaultEndpoint(const std::string& topic)
+{
+#ifdef _WIN32
+    size_t h = std::hash<std::string>{}(topic);
+    return "tcp://127.0.0.1:" + std::to_string(20000 + (h % 10000));
+#else
+    return "ipc:///tmp/" + topic + ".ipc";
+#endif
+}
+
+inline void sendDiscovery(const std::string& topic, const std::string& endpoint)
+{
+    try {
+        UdpMultiCast mc{"239.255.0.1", 30000};
+        std::string msg = topic + ':' + endpoint;
+        mc.send(msg);
+    } catch (...) {
+    }
+}
+
+inline std::optional<std::string> waitDiscovery(const std::string& topic, std::chrono::milliseconds timeout = std::chrono::milliseconds{200})
+{
+    try {
+        UdpMultiCast mc{"239.255.0.1", 30000};
+        mc.bind();
+        char buf[256];
+        SockAddr from{};
+        auto start = std::chrono::steady_clock::now();
+        while (std::chrono::steady_clock::now() - start < timeout) {
+            int ret = mc.recvFrom(buf, sizeof(buf)-1, from);
+            if (ret > 0) {
+                buf[ret] = '\0';
+                std::string s(buf);
+                auto pos = s.find(':');
+                if (pos != std::string::npos) {
+                    std::string t = s.substr(0, pos);
+                    if (t == topic) {
+                        return s.substr(pos+1);
+                    }
+                }
+            }
+        }
+    } catch (...) {
+    }
+    return std::nullopt;
+}
+
+template<typename T>
+class LUX_COMMUNICATION_PUBLIC Publisher
+{
+public:
+    explicit Publisher(const std::string& topic, std::string endpoint = defaultEndpoint(topic))
+        : topic_(topic), endpoint_(std::move(endpoint)), socket_(globalContext(), zmq::socket_type::pub)
+    {
+        socket_.bind(endpoint_);
+        sendDiscovery(topic_, endpoint_);
+    }
+
+    void publish(const T& msg)
+    {
+        zmq::message_t m(sizeof(T));
+        std::memcpy(m.data(), &msg, sizeof(T));
+        socket_.send(m, zmq::send_flags::none);
+    }
+
+private:
+    std::string topic_;
+    std::string endpoint_;
+    zmq::socket_t socket_;
+};
+
+template<typename T, typename Callback>
+class LUX_COMMUNICATION_PUBLIC Subscriber
+{
+public:
+    Subscriber(const std::string& topic, Callback cb)
+        : topic_(topic), callback_(std::move(cb)), socket_(globalContext(), zmq::socket_type::sub)
+    {
+        auto ep = waitDiscovery(topic_);
+        if (!ep) {
+            endpoint_ = defaultEndpoint(topic_);
+        } else {
+            endpoint_ = *ep;
+        }
+        socket_.set(zmq::sockopt::subscribe, "");
+        socket_.connect(endpoint_);
+        running_ = true;
+        thread_ = std::thread([this]{ recvLoop(); });
+    }
+
+    ~Subscriber()
+    {
+        stop();
+    }
+
+    void stop()
+    {
+        if (running_) {
+            running_ = false;
+            if (thread_.joinable())
+                thread_.join();
+        }
+    }
+
+private:
+    void recvLoop()
+    {
+        while (running_) {
+            zmq::message_t msg;
+            if (socket_.recv(msg, zmq::recv_flags::none)) {
+                T value;
+                std::memcpy(&value, msg.data(), sizeof(T));
+                callback_(value);
+            }
+        }
+    }
+
+    std::string topic_;
+    std::string endpoint_;
+    zmq::socket_t socket_;
+    Callback callback_;
+    std::thread thread_;
+    std::atomic<bool> running_{false};
+};
+
+} // namespace lux::communication::interprocess
+

--- a/node/include/lux/communication/introprocess/Node.hpp
+++ b/node/include/lux/communication/introprocess/Node.hpp
@@ -5,17 +5,21 @@
 #include <atomic>
 #include <functional>
 #include <memory>
-#include "Domain.hpp"
+#include <lux/communication/visibility.h>
+#include <lux/communication/Domain.hpp>
 #include "Publisher.hpp"
 #include "Subscriber.hpp"
-#include "Executor.hpp"
+#include <lux/communication/Executor.hpp>
 
 #include <lux/cxx/compile_time/type_info.hpp>
 #include <lux/cxx/container/SparseSet.hpp>
 
 namespace lux::communication::introprocess
 {
-    class Node
+    using lux::communication::Domain;
+    using lux::communication::CallbackGroup;
+    using lux::communication::CallbackGroupType;
+    class LUX_COMMUNICATION_PUBLIC Node
     {
     public:
         // Basic record structures remain the same
@@ -263,7 +267,9 @@ namespace lux::communication::introprocess
         }
     }
 
-    void Executor::addNode(std::shared_ptr<Node> node)
+}
+
+inline void lux::communication::Executor::addNode(std::shared_ptr<lux::communication::introprocess::Node> node)
     {
         if (!node) return;
         // For example, add the node's default callback group to the Executor
@@ -275,4 +281,4 @@ namespace lux::communication::introprocess
         // If you want to add all subscriber callback groups under the node more granularly,
         // you can implement more complex interfaces in Node.
     }
-}
+

--- a/node/include/lux/communication/introprocess/Publisher.hpp
+++ b/node/include/lux/communication/introprocess/Publisher.hpp
@@ -3,13 +3,14 @@
 #include <string>
 #include <memory>
 #include <cassert>
+#include <lux/communication/visibility.h>
 #include "Topic.hpp"
 
 namespace lux::communication::introprocess
 {
     class Node;
     template <typename T>
-    class Publisher
+    class LUX_COMMUNICATION_PUBLIC Publisher
     {
     public:
         friend class Node;

--- a/node/include/lux/communication/introprocess/Subscriber.hpp
+++ b/node/include/lux/communication/introprocess/Subscriber.hpp
@@ -1,14 +1,18 @@
 #pragma once
 #include <functional>
 #include <memory>
-#include "Queue.hpp"
+#include <lux/communication/Queue.hpp>
 #include "Topic.hpp"
-#include "SubscriberBase.hpp"
-#include "CallbackGroup.hpp"
+#include <lux/communication/SubscriberBase.hpp>
+#include <lux/communication/CallbackGroup.hpp>
+#include <lux/communication/visibility.h>
 #include <lux/communication/builtin_msgs/common_msgs/timestamp.st.h>
 
 namespace lux::communication::introprocess
 {
+    using lux::communication::CallbackGroup;
+    using lux::communication::CallbackGroupType;
+    using lux::communication::ISubscriberBase;
     template <typename T>
     using SubscriberCallback = std::function<void(const std::shared_ptr<T>)>;
 
@@ -22,7 +26,7 @@ namespace lux::communication::introprocess
 
     class Node; // Forward declaration
     template <typename T>
-    class Subscriber : public ISubscriberBase
+    class LUX_COMMUNICATION_PUBLIC Subscriber : public ISubscriberBase
     {
     public:
         using Callback = std::function<void(const T &)>;

--- a/node/include/lux/communication/introprocess/Topic.hpp
+++ b/node/include/lux/communication/introprocess/Topic.hpp
@@ -7,10 +7,12 @@
 #include <memory>    // for std::unique_ptr
 #include "ITopicHolder.hpp"
 
+namespace lux::communication { class Domain; }
+
 namespace lux::communication::introprocess
 {
     // Forward declaration
-    class Domain;
+    using ::lux::communication::Domain;
     template <typename T>
     class Subscriber;
 

--- a/node/test/node_test.cpp
+++ b/node/test/node_test.cpp
@@ -8,7 +8,7 @@
 
 // include headers according to project layout
 #include <lux/communication/introprocess/Node.hpp>
-#include <lux/communication/introprocess/Executor.hpp>
+#include <lux/communication/Executor.hpp>
 
 struct StringMsg
 {
@@ -57,7 +57,7 @@ void testDomainIsolation()
     );
 
     // Executor running nodeB
-    auto execB = std::make_shared<SingleThreadedExecutor>();
+    auto execB = std::make_shared<lux::communication::SingleThreadedExecutor>();
     // Add nodeB to the executor (default callback group)
     execB->addNode(nodeB);
 
@@ -117,7 +117,7 @@ void testSingleDomainMultiNode()
             });
 
         // Executor for nodeB
-        auto execB = std::make_shared<SingleThreadedExecutor>();
+        auto execB = std::make_shared<lux::communication::SingleThreadedExecutor>();
         execB->addNode(nodeB);
 
         // Start a thread to spin nodeB
@@ -194,7 +194,7 @@ void testMultiSubscriber()
         });
 
     // Executor for nodeB
-    auto execB = std::make_shared<SingleThreadedExecutor>();
+    auto execB = std::make_shared<lux::communication::SingleThreadedExecutor>();
     execB->addNode(nodeB);
     std::thread spinTh([&]{ execB->spin(); });
 
@@ -250,7 +250,7 @@ void testZeroCopyCheck()
     auto pub = node->createPublisher<StringMsg>("nocopy");
 
     // Executor
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
 
     std::thread th([&]{ exec->spin(); });
@@ -299,7 +299,7 @@ void testPerformanceSinglePubSub(int messageCount = 100000)
     auto pub = node->createPublisher<StringMsg>("perf_topic");
 
     // Executor
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
 
     std::thread spinTh([&]{
@@ -367,7 +367,7 @@ void testPerformanceMultiSubscriber(int subscriberCount = 5, int messageCount = 
     auto pub = node->createPublisher<StringMsg>("multi_perf");
 
     // Executor
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
     std::thread spinTh([&]{ exec->spin(); });
 
@@ -454,7 +454,7 @@ void testLatencySinglePubSub(int messageCount = 1000)
     auto pub = node->createPublisher<TimeStampedMsg>("latency_topic");
 
     // 5) Start Executor
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
 
     std::thread spinTh([&]{
@@ -533,8 +533,8 @@ void testMultiThreadedExecutorBasic(int threadCount = 4, int messageCount = 5000
         subs.push_back(s);
     }
 
-    // 4. Create MultiThreadedExecutor and add Node
-    auto exec = std::make_shared<MultiThreadedExecutor>(threadCount);
+    // 4. Create lux::communication::MultiThreadedExecutor and add Node
+    auto exec = std::make_shared<lux::communication::MultiThreadedExecutor>(threadCount);
     exec->addNode(node);
 
     // 5. Start spinning (threads process concurrently)
@@ -640,10 +640,10 @@ void testMultiThreadedExecutorWithCallbackGroups(int threadCount = 4, int messag
     // 5) Create Publisher
     auto pub = node->createPublisher<StringMsg>("group_topic");
 
-    // 6) Create MultiThreadedExecutor and add both groups
+    // 6) Create lux::communication::MultiThreadedExecutor and add both groups
     //    Note: addNode(node) would also add the default group
     //    Here we manually add groupR and groupM for clarity
-    auto exec = std::make_shared<MultiThreadedExecutor>(4);
+    auto exec = std::make_shared<lux::communication::MultiThreadedExecutor>(4);
     //exec->addNode(node); // alternatively add the whole node
     // or manually add both groups
     exec->addCallbackGroup(groupR);
@@ -715,7 +715,7 @@ void testPerformanceLargeMessage(int messageCount = 1000, size_t size = 1024*102
 
     auto pub = node->createPublisher<LargeMsg>("big_topic");
 
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
 
     std::thread th([&]{ exec->spin(); });
@@ -752,7 +752,7 @@ void testThreadLifecycleSafety()
     auto domain = std::make_shared<Domain>(1);
     auto node   = std::make_shared<Node>("LifeNode", domain);
 
-    auto exec = std::make_shared<MultiThreadedExecutor>(2);
+    auto exec = std::make_shared<lux::communication::MultiThreadedExecutor>(2);
     exec->addNode(node);
 
     std::atomic<bool> running{true};
@@ -815,7 +815,7 @@ void testMemoryLeakCheck(int messageCount = 1000)
 
     auto pub = node->createPublisher<CountingMsg>("mem_topic");
 
-    auto exec = std::make_shared<SingleThreadedExecutor>();
+    auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
     exec->addNode(node);
 
     std::thread spinTh([&]{ exec->spin(); });

--- a/node/test/timeorder_executor_test.cpp
+++ b/node/test/timeorder_executor_test.cpp
@@ -25,7 +25,7 @@ void run_test_with_offset(std::chrono::nanoseconds offset,
     auto node   = std::make_shared<lux::communication::introprocess::Node>("test_node", domain);
 
     // 2) Create TimeOrderedExecutor with a delay window
-    auto timeExec = std::make_shared<lux::communication::introprocess::TimeOrderedExecutor>(offset);
+    auto timeExec = std::make_shared<lux::communication::TimeOrderedExecutor>(offset);
     // Add the node's default callback group to the executor
     timeExec->addNode(node);
 


### PR DESCRIPTION
## Summary
- move common headers to shared communication directory
- mark public classes with `LUX_COMMUNICATION_PUBLIC`
- adjust namespaces and includes after refactor
- update tests for new executor namespaces

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(no tests were found)*