### PR TITLE
Implement interprocess discovery fallback

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -30,13 +30,13 @@ component_include_directories(
 )
 
 target_link_libraries(
-	node 
-	PUBLIC
-	# cppzmq
-	lux::cxx::concurrent
-	lux::cxx::compile_time
-	PRIVATE
-	stduuid
+        node
+        PUBLIC
+        cppzmq
+        lux::cxx::concurrent
+        lux::cxx::compile_time
+        PRIVATE
+        stduuid
 )
 
 component_add_internal_dependencies(

--- a/node/include/lux/communication/CallbackGroup.hpp
+++ b/node/include/lux/communication/CallbackGroup.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <memory>
+#include <algorithm>
 #include <mutex>
 #include <atomic>
 #include <functional>
@@ -48,6 +49,11 @@ namespace lux::communication
             std::lock_guard<std::mutex> lock(mutex_);
             if (!sub) return;
             subscribers_.erase(sub->getId());
+            auto it = std::find(ready_list_.begin(), ready_list_.end(), sub);
+            if (it != ready_list_.end())
+            {
+                ready_list_.erase(it);
+            }
         }
 
 		bool hasReadySubscribers() const

--- a/node/include/lux/communication/interprocess/Node.hpp
+++ b/node/include/lux/communication/interprocess/Node.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <vector>
+#include <functional>
+
+#include <lux/communication/CallbackGroup.hpp>
+#include <lux/communication/interprocess/ZmqPubSub.hpp>
+#include <lux/communication/visibility.h>
+
+namespace lux::communication::interprocess {
+
+class Node {
+public:
+    explicit Node(const std::string& name)
+        : name_(name)
+    {
+        default_group_ = std::make_shared<lux::communication::CallbackGroup>(
+            lux::communication::CallbackGroupType::MutuallyExclusive);
+    }
+
+    ~Node() { stop(); }
+
+    std::shared_ptr<lux::communication::CallbackGroup> getDefaultCallbackGroup() const
+    {
+        return default_group_;
+    }
+
+    template<typename T>
+    std::shared_ptr<Publisher<T>> createPublisher(const std::string& topic)
+    {
+        return std::make_shared<Publisher<T>>(topic);
+    }
+
+    template<typename T, typename Callback>
+    std::shared_ptr<Subscriber<T, std::decay_t<Callback>>> createSubscriber(
+        const std::string& topic, Callback&& cb,
+        std::shared_ptr<lux::communication::CallbackGroup> group = nullptr)
+    {
+        (void)group;
+        auto sub = std::make_shared<Subscriber<T, std::decay_t<Callback>>>(
+            topic, std::forward<Callback>(cb));
+        subscriber_stoppers_.emplace_back([s=sub]{ s->stop(); });
+        return sub;
+    }
+
+    void stop()
+    {
+        for (auto& fn : subscriber_stoppers_) { fn(); }
+        subscriber_stoppers_.clear();
+    }
+
+private:
+    std::string name_;
+    std::shared_ptr<lux::communication::CallbackGroup> default_group_;
+    std::vector<std::function<void()>> subscriber_stoppers_;
+};
+
+} // namespace lux::communication::interprocess

--- a/node/test/CMakeLists.txt
+++ b/node/test/CMakeLists.txt
@@ -3,3 +3,11 @@ target_link_libraries(node_test PRIVATE lux::communication::node)
 
 add_executable(timeorder_executor_test timeorder_executor_test.cpp)
 target_link_libraries(timeorder_executor_test PRIVATE lux::communication::node)
+
+
+
+add_executable(executor_interprocess_test executor_interprocess_test.cpp)
+target_link_libraries(executor_interprocess_test PRIVATE lux::communication::node)
+
+add_executable(communication_intra_inter_test communication_intra_inter_test.cpp)
+target_link_libraries(communication_intra_inter_test PRIVATE lux::communication::node)

--- a/node/test/executor_interprocess_test.cpp
+++ b/node/test/executor_interprocess_test.cpp
@@ -5,7 +5,8 @@
 #include <memory>
 
 #include <lux/communication/interprocess/Node.hpp>
-#include <lux/communication/introprocess/Executor.hpp>
+#include <lux/communication/Executor.hpp>
+#include <lux/communication/introprocess/Node.hpp> // for Executor::addNode definition
 
 struct IntMsg { int value; };
 
@@ -16,7 +17,7 @@ void runExecutorInterprocess()
     interprocess::Node nodeSub("sub");
 
     std::atomic<int> count{0};
-    auto exec = std::make_shared<introprocess::SingleThreadedExecutor>();
+    auto exec = std::make_shared<SingleThreadedExecutor>();
     exec->addCallbackGroup(nodeSub.getDefaultCallbackGroup());
     std::thread th([&]{ exec->spin(); });
 


### PR DESCRIPTION
## Summary
- disable blocking discovery in ZeroMQ interprocess layer
- compile all node tests including intra/inter communication

## Testing
- `cmake --build build -j4`
- `./build/node/test/node_test`
- `./build/node/test/timeorder_executor_test`
- `./build/node/test/communication_intra_inter_test`
- `./build/node/test/executor_interprocess_test`
