### PR TITLE
Fix Node subscriber handling and improve interprocess test

### DIFF
--- a/node/include/lux/communication/introprocess/Node.hpp
+++ b/node/include/lux/communication/introprocess/Node.hpp
@@ -135,6 +135,13 @@ namespace lux::communication::introprocess
             // 4) Construct the Subscriber
             auto sub = std::make_shared<Subscriber<T>>(this, sub_id, topic_ptr, std::forward<Func>(cb), group);
 
+            // Register the subscriber with its callback group so that
+            // Executor::spinSome() can collect it when data arrives.
+            if (group)
+            {
+                group->addSubscriber(sub.get());
+            }
+
             // 5) Record in the SparseSet
             SubscriberRecord sub_record{
                 .id = sub_id,


### PR DESCRIPTION
## Summary
- register subscribers with their callback groups so the executor can dispatch them
- expand the interprocess executor test to use two subscribers and verify delivery

## Testing
- `cmake --build build -j4`
- `timeout 20s ./build/node/test/executor_interprocess_test`