### PR TITLE
Unify interprocess communication with intraprocess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(lux-communication)
+enable_testing()
 
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX d)

--- a/node/include/lux/communication/interprocess/Node.hpp
+++ b/node/include/lux/communication/interprocess/Node.hpp
@@ -5,9 +5,11 @@
 
 #include <vector>
 #include <functional>
+#include <atomic>
 
 #include <lux/communication/CallbackGroup.hpp>
 #include <lux/communication/interprocess/ZmqPubSub.hpp>
+#include <lux/communication/Executor.hpp>
 #include <lux/communication/visibility.h>
 
 namespace lux::communication::interprocess {
@@ -19,6 +21,7 @@ public:
     {
         default_group_ = std::make_shared<lux::communication::CallbackGroup>(
             lux::communication::CallbackGroupType::MutuallyExclusive);
+        callback_groups_.push_back(default_group_);
     }
 
     ~Node() { stop(); }
@@ -35,27 +38,66 @@ public:
     }
 
     template<typename T, typename Callback>
-    std::shared_ptr<Subscriber<T, std::decay_t<Callback>>> createSubscriber(
+    std::shared_ptr<Subscriber<T>> createSubscriber(
         const std::string& topic, Callback&& cb,
         std::shared_ptr<lux::communication::CallbackGroup> group = nullptr)
     {
-        (void)group;
-        auto sub = std::make_shared<Subscriber<T, std::decay_t<Callback>>>(
-            topic, std::forward<Callback>(cb));
+        if (!group)
+        {
+            group = default_group_;
+        }
+        auto sub = std::make_shared<Subscriber<T>>(topic, std::forward<Callback>(cb), group, next_sub_id_++);
+        if (group)
+        {
+            group->addSubscriber(sub.get());
+            bool exists = false;
+            for (auto& g : callback_groups_)
+            {
+                if (g == group)
+                {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists)
+            {
+                callback_groups_.push_back(group);
+            }
+        }
         subscriber_stoppers_.emplace_back([s=sub]{ s->stop(); });
         return sub;
     }
 
     void stop()
     {
+        auto exec = spinning_exec_.load();
+        if (exec)
+        {
+            exec->stop();
+        }
         for (auto& fn : subscriber_stoppers_) { fn(); }
         subscriber_stoppers_.clear();
+    }
+
+    void spin()
+    {
+        auto exec = std::make_shared<lux::communication::SingleThreadedExecutor>();
+        for (auto& g : callback_groups_)
+        {
+            exec->addCallbackGroup(g);
+        }
+        spinning_exec_.store(exec.get(), std::memory_order_release);
+        exec->spin();
+        spinning_exec_.store(nullptr, std::memory_order_release);
     }
 
 private:
     std::string name_;
     std::shared_ptr<lux::communication::CallbackGroup> default_group_;
+    std::vector<std::shared_ptr<lux::communication::CallbackGroup>> callback_groups_;
     std::vector<std::function<void()>> subscriber_stoppers_;
+    std::atomic<lux::communication::Executor*> spinning_exec_{nullptr};
+    int next_sub_id_{0};
 };
 
 } // namespace lux::communication::interprocess

--- a/node/include/lux/communication/interprocess/ZmqPubSub.hpp
+++ b/node/include/lux/communication/interprocess/ZmqPubSub.hpp
@@ -10,6 +10,10 @@
 
 #include <lux/communication/visibility.h>
 #include "lux/communication/UdpMultiCast.hpp"
+#include <lux/communication/Queue.hpp>
+#include <lux/communication/SubscriberBase.hpp>
+#include <lux/communication/CallbackGroup.hpp>
+#include <lux/communication/builtin_msgs/common_msgs/timestamp.st.h>
 
 namespace lux::communication::interprocess {
 
@@ -73,12 +77,21 @@ private:
     zmq::socket_t socket_;
 };
 
-template<typename T, typename Callback>
-class Subscriber
+template<typename T>
+class Subscriber : public lux::communication::ISubscriberBase
 {
 public:
-    Subscriber(const std::string& topic, Callback cb)
-        : topic_(topic), callback_(std::move(cb)), socket_(globalContext(), zmq::socket_type::sub)
+    using Callback = std::function<void(const T&)>;
+
+    Subscriber(const std::string& topic,
+               Callback cb,
+               std::shared_ptr<lux::communication::CallbackGroup> group,
+               int id)
+        : ISubscriberBase(id),
+          topic_(topic),
+          callback_(std::move(cb)),
+          callback_group_(std::move(group)),
+          socket_(globalContext(), zmq::socket_type::sub)
     {
         auto ep = waitDiscovery(topic_);
         if (!ep) {
@@ -96,30 +109,94 @@ public:
 
     ~Subscriber()
     {
-        stop();
+        cleanup();
     }
 
     void stop()
     {
-        if (running_) {
-            running_ = false;
-            if (thread_.joinable())
-                thread_.join();
+        cleanup();
+    }
+
+    void takeAll() override
+    {
+        message_t<T> msg;
+        while (try_pop(queue_, msg))
+        {
+            if (callback_)
+            {
+                callback_(*msg);
+            }
         }
+        clearReady();
+    }
+
+    bool setReadyIfNot() override
+    {
+        bool expected = false;
+        return ready_flag_.compare_exchange_strong(
+            expected, true,
+            std::memory_order_acq_rel, std::memory_order_acquire);
+    }
+
+    void clearReady() override
+    {
+        ready_flag_.store(false, std::memory_order_release);
     }
 
 private:
     void recvLoop()
     {
-        while (running_) {
+        while (running_)
+        {
             zmq::message_t msg;
             auto result = socket_.recv(msg, zmq::recv_flags::none);
-            if (!result) {
+            if (!result)
+            {
                 continue; // timeout
             }
             T value;
             std::memcpy(&value, msg.data(), sizeof(T));
-            callback_(value);
+            auto ptr = std::make_shared<T>(std::move(value));
+            push(queue_, std::move(ptr));
+            if (callback_group_ && setReadyIfNot())
+            {
+                callback_group_->notify(this);
+            }
+        }
+    }
+
+    void cleanup()
+    {
+        if (running_)
+        {
+            running_ = false;
+            if (thread_.joinable())
+                thread_.join();
+        }
+        close(queue_);
+        if (callback_group_)
+        {
+            callback_group_->removeSubscriber(this);
+        }
+    }
+
+    void drainAll(std::vector<lux::communication::TimeExecEntry>& out) override
+    {
+        if constexpr(lux::communication::is_msg_stamped<T>)
+        {
+            message_t<T> msg;
+            while (try_pop(queue_, msg))
+            {
+                uint64_t ts_ns = lux::communication::builtin_msgs::common_msgs::extract_timstamp(*msg);
+                auto invoker = [cb=callback_, m=std::move(msg)]() mutable {
+                    if (cb) { cb(*m); }
+                };
+                out.push_back(lux::communication::TimeExecEntry{ ts_ns, std::move(invoker) });
+            }
+        }
+        else
+        {
+            throw std::runtime_error("Subscriber<T> does not support non-stamped message type T");
         }
     }
 
@@ -127,8 +204,12 @@ private:
     std::string endpoint_;
     zmq::socket_t socket_;
     Callback callback_;
+    std::shared_ptr<lux::communication::CallbackGroup> callback_group_;
     std::thread thread_;
     std::atomic<bool> running_{false};
+
+    lux::communication::queue_t<T> queue_;
+    std::atomic<bool> ready_flag_{false};
 };
 
 } // namespace lux::communication::interprocess

--- a/node/test/CMakeLists.txt
+++ b/node/test/CMakeLists.txt
@@ -1,17 +1,29 @@
+enable_testing()
+
 add_executable(node_test node_test.cpp)
 target_link_libraries(node_test PRIVATE lux::communication::node)
+add_test(NAME node_test COMMAND node_test)
 
 add_executable(timeorder_executor_test timeorder_executor_test.cpp)
 target_link_libraries(timeorder_executor_test PRIVATE lux::communication::node)
+add_test(NAME timeorder_executor_test COMMAND timeorder_executor_test)
 
 add_executable(executor_interprocess_test executor_interprocess_test.cpp)
 target_link_libraries(executor_interprocess_test PRIVATE lux::communication::node)
+add_test(NAME executor_interprocess_test COMMAND executor_interprocess_test)
 
 add_executable(communication_intra_inter_test communication_intra_inter_test.cpp)
 target_link_libraries(communication_intra_inter_test PRIVATE lux::communication::node)
+add_test(NAME communication_intra_inter_test COMMAND communication_intra_inter_test)
 
 add_executable(discovery_test discovery_test.cpp)
 target_link_libraries(discovery_test PRIVATE lux::communication::node)
+add_test(NAME discovery_test COMMAND discovery_test)
 
 add_executable(interprocess_performance_test interprocess_performance_test.cpp)
 target_link_libraries(interprocess_performance_test PRIVATE lux::communication::node)
+# Performance test is not added to ctest by default to keep test time reasonable
+
+add_executable(interprocess_spin_test interprocess_spin_test.cpp)
+target_link_libraries(interprocess_spin_test PRIVATE lux::communication::node)
+add_test(NAME interprocess_spin_test COMMAND interprocess_spin_test)

--- a/node/test/interprocess_spin_test.cpp
+++ b/node/test/interprocess_spin_test.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+#include <atomic>
+#include <memory>
+
+#include <lux/communication/interprocess/Node.hpp>
+#include <lux/communication/introprocess/Node.hpp> // for Executor::addNode definition
+
+struct Msg { int value; };
+
+static void runSpinTest()
+{
+    using namespace lux::communication;
+    interprocess::Node nodePub("pub");
+    interprocess::Node nodeSub("sub");
+
+    auto group2 = std::make_shared<CallbackGroup>(CallbackGroupType::MutuallyExclusive);
+    std::atomic<int> count1{0};
+    std::atomic<int> count2{0};
+
+    auto sub1 = nodeSub.createSubscriber<Msg>("topic", [&](const Msg&){ count1++; });
+    auto sub2 = nodeSub.createSubscriber<Msg>("topic", [&](const Msg&){ count2++; }, group2);
+
+    std::thread spinThread([&]{ nodeSub.spin(); });
+
+    auto pub = nodePub.createPublisher<Msg>("topic");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    for(int i=0;i<5;++i)
+    {
+        pub->publish(Msg{i});
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    nodeSub.stop();
+    spinThread.join();
+    nodePub.stop();
+
+    std::cout << "sub1=" << count1.load() << " sub2=" << count2.load() << std::endl;
+}
+
+int main()
+{
+    runSpinTest();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `enable_testing()` and register node tests with ctest
- support spinning in interprocess Node with executor
- collect callback groups when subscribers are created
- add new `interprocess_spin_test`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure`