### PR TITLE
Refactor interprocess Node to rely on Executor

### DIFF
--- a/node/test/communication_intra_inter_test.cpp
+++ b/node/test/communication_intra_inter_test.cpp
@@ -17,8 +17,9 @@ void testLifecycle()
     using namespace lux::communication;
     std::cout << "\n=== lifecycle test ===\n";
     {
-        interprocess::Node nodeA("A");
-        interprocess::Node nodeB("B");
+        auto domain = std::make_shared<introprocess::Domain>(1);
+        interprocess::Node nodeA("A", domain);
+        interprocess::Node nodeB("B", domain);
 
         std::atomic<int> count{0};
         auto sub = nodeB.createSubscriber<Msg>("ping", [&](const Msg&m){count++;});
@@ -39,7 +40,7 @@ void testIntraInter()
     std::cout << "\n=== intra & inter mixed ===\n";
     auto domain = std::make_shared<introprocess::Domain>(1);
     auto inode = std::make_shared<introprocess::Node>("inode", domain);
-    interprocess::Node pnode("pnode");
+    interprocess::Node pnode("pnode", domain);
 
     std::atomic<int> intraCount{0}, interCount{0};
 

--- a/node/test/discovery_test.cpp
+++ b/node/test/discovery_test.cpp
@@ -13,7 +13,8 @@ struct IntMsg { int value; };
 static void runDiscoveryTest()
 {
     using namespace lux::communication;
-    interprocess::Node node_sub("sub");
+    auto domain = std::make_shared<introprocess::Domain>(1);
+    interprocess::Node node_sub("sub", domain);
     std::atomic<int> count{0};
 
     auto exec = std::make_shared<SingleThreadedExecutor>();
@@ -24,7 +25,7 @@ static void runDiscoveryTest()
     // Start publisher a bit later to test discovery
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-    interprocess::Node nodePub("pub");
+    interprocess::Node nodePub("pub", domain);
     auto pub = nodePub.createPublisher<IntMsg>("topic");
 
     // Give subscriber time to connect to the new publisher

--- a/node/test/executor_interprocess_test.cpp
+++ b/node/test/executor_interprocess_test.cpp
@@ -15,8 +15,9 @@ void runExecutorInterprocess()
     using namespace lux::communication;
 
     // Publisher node and subscriber node
-    interprocess::Node nodePub("pub");
-    interprocess::Node nodeSub("sub");
+    auto domain = std::make_shared<introprocess::Domain>(1);
+    interprocess::Node nodePub("pub", domain);
+    interprocess::Node nodeSub("sub", domain);
 
     std::atomic<int> subCount1{0};
     std::atomic<int> subCount2{0};

--- a/node/test/interprocess_performance_test.cpp
+++ b/node/test/interprocess_performance_test.cpp
@@ -15,8 +15,9 @@ template<size_t SIZE>
 void throughputTest(int messageCount = 100000)
 {
     using namespace lux::communication;
-    interprocess::Node nodePub("pub");
-    interprocess::Node nodeSub("sub");
+    auto domain = std::make_shared<introprocess::Domain>(1);
+    interprocess::Node nodePub("pub", domain);
+    interprocess::Node nodeSub("sub", domain);
 
     struct Msg { std::array<uint8_t, SIZE> data; };
 


### PR DESCRIPTION
## Summary
- remove spin() from `interprocess::Node`
- allow interprocess nodes to take a `Domain` like intraprocess nodes
- update interprocess tests to use an external executor

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure`