### PR TITLE
Fix executor concurrency and misc issues

### DIFF
--- a/node/include/lux/communication/CallbackGroup.hpp
+++ b/node/include/lux/communication/CallbackGroup.hpp
@@ -56,10 +56,11 @@ namespace lux::communication
             }
         }
 
-		bool hasReadySubscribers() const
-		{
-			return !ready_list_.empty();
-		}
+        bool hasReadySubscribers() const
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            return !ready_list_.empty();
+        }
 
         // When a particular Subscriber has new data
         // The purpose is to add the Subscriber to the "ready queue" and notify the Executor

--- a/node/include/lux/communication/Domain.hpp
+++ b/node/include/lux/communication/Domain.hpp
@@ -39,8 +39,8 @@ namespace lux::communication
             {
                 // Already exists
                 size_t idx = it->second;
-                auto ptr = dynamic_cast<intraprocess::Topic<T> *>(topics_[idx].get());
-                assert(ptr && "Topic type mismatch!");
+                assert(topics_[idx]->getType() == intraprocess::Topic<T>::type_info && "Topic type mismatch!");
+                auto ptr = static_cast<intraprocess::Topic<T> *>(topics_[idx].get());
                 ptr->incRef();
                 return ptr;
             }
@@ -53,7 +53,7 @@ namespace lux::communication
                 size_t newIdx = topics_.size() - 1;
                 topic_index_map_[key] = newIdx;
 
-                return dynamic_cast<intraprocess::Topic<T> *>(topics_[newIdx].get());
+                return static_cast<intraprocess::Topic<T> *>(topics_[newIdx].get());
             }
         }
 

--- a/node/include/lux/communication/Queue.hpp
+++ b/node/include/lux/communication/Queue.hpp
@@ -22,11 +22,13 @@ namespace lux::communication
 #if defined(LUX_HAS_MOODYCAMEL_CONCURRENTQUEUE)
     template<typename T> using queue_t = moodycamel::ConcurrentQueue<message_t<T>>;
     template<typename T> static inline bool try_pop(queue_t<T> &q, message_t<T>& msg) { return q.try_dequeue(msg); }
+    template<typename T> static inline bool try_dequeue(queue_t<T>& q, message_t<T>& msg) { return q.try_dequeue(msg); }
     template<typename T> static inline void push(queue_t<T> &q, message_t<T> msg) { q.enqueue(std::move(msg)); }
     template<typename T> static inline void close(queue_t<T> &q) {}
 #else
     template<typename T> using queue_t = lux::cxx::BlockingQueue<message_t<T>>;
     template<typename T> static inline bool try_pop(queue_t<T>& q, message_t<T>& msg) { return q.try_pop(msg); }
+    template<typename T> static inline bool try_dequeue(queue_t<T>& q, message_t<T>& msg) { return q.try_pop(msg); }
     template<typename T> static inline void push(queue_t<T>& q, message_t<T> msg) { q.push(std::move(msg)); }
     template<typename T> static inline void close(queue_t<T>& q) { q.close(); }
 #endif

--- a/node/include/lux/communication/SubscriberBase.hpp
+++ b/node/include/lux/communication/SubscriberBase.hpp
@@ -2,14 +2,13 @@
 #include <functional>
 #include <cstddef>
 #include <lux/communication/visibility.h>
-#include <lux/cxx/compile_time/move_only_function.hpp>
 
 namespace lux::communication
 {
     struct TimeExecEntry
     {
         uint64_t timestamp_ns;
-        lux::cxx::move_only_function<void ()> invoker;
+        std::function<void ()> invoker;
         
         bool operator<(const TimeExecEntry &rhs) const
         {


### PR DESCRIPTION
## Summary
- guard CallbackGroup ready list accesses with a mutex
- avoid duplicate ready entries in CallbackGroup::notify
- protect Executor callback_groups_ with a mutex
- dispatch MultiThreadedExecutor callbacks without waiting
- make TimeExecEntry copyable and remove UB in time-ordered executor
- use type check instead of dynamic_cast in Domain
- add try_dequeue alias for BlockingQueue

## Testing
- `cmake ..`
- `cmake --build . --target node_test`
- `ctest --output-on-failure`