### PR TITLE
Update node tests and headers for new node API

### DIFF
--- a/node/include/lux/communication/CallbackGroupBase.hpp
+++ b/node/include/lux/communication/CallbackGroupBase.hpp
@@ -9,6 +9,7 @@ namespace lux::communication
     // Forward declarations
 	class NodeBase;
     class Executor;
+    class ExecutorBase;
     class SubscriberBase;
 
     enum class CallbackGroupType

--- a/node/include/lux/communication/NodeBase.hpp
+++ b/node/include/lux/communication/NodeBase.hpp
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <lux/cxx/container/SparseSet.hpp>
 #include <lux/communication/visibility.h>
+#include <lux/communication/ExecutorBase.hpp>
 
 namespace lux::communication
 {

--- a/node/include/lux/communication/PublisherBase.hpp
+++ b/node/include/lux/communication/PublisherBase.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <string>
+#include <limits>
 #include <lux/communication/visibility.h>
 
 namespace lux::communication

--- a/node/include/lux/communication/SubscriberBase.hpp
+++ b/node/include/lux/communication/SubscriberBase.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <limits>
 #include <functional>
 
 #include <lux/communication/TimeExecEntry.hpp>

--- a/node/include/lux/communication/TimeExecEntry.hpp
+++ b/node/include/lux/communication/TimeExecEntry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <cstddef>
+#include <cstdint>
 
 namespace lux::communication
 {

--- a/node/test/CMakeLists.txt
+++ b/node/test/CMakeLists.txt
@@ -1,18 +1,7 @@
-find_library(JEMALLOC_LIB jemalloc REQUIRED)
-
-#[[
 add_executable(node_test node_test.cpp)
-target_link_libraries(node_test PRIVATE lux::communication::node ${JEMALLOC_LIB})
+target_link_libraries(node_test PRIVATE lux::communication::node)
 
-add_executable(timeorder_executor_test timeorder_executor_test.cpp)
-target_link_libraries(timeorder_executor_test PRIVATE lux::communication::node)
 
-add_executable(interprocess_subscriber interprocess_subscriber.cpp)
-target_link_libraries(interprocess_subscriber PRIVATE lux::communication::node)
-
-add_executable(interprocess_publisher interprocess_publisher.cpp)
-target_link_libraries(interprocess_publisher PRIVATE lux::communication::node)
-]]
 
 add_executable(node_simple_test simple_test.cpp)
 target_link_libraries(node_simple_test PRIVATE lux::communication::node)


### PR DESCRIPTION
## Summary
- update Node headers to include required dependencies
- adapt TimeExecEntry for uint64_t timestamp
- rewrite large node_test to use new intraprocess API
- simplify test CMakeLists

## Testing
- `cmake --build . --target node_simple_test node_test`

------
https://chatgpt.com/codex/tasks/task_e_685185819644832ab1680a2a71156453